### PR TITLE
Add error catchall and add helper text to some routes

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -17,8 +17,10 @@ declare global {
 		interface PageData {
 			session: Session | null;
 		}
+		interface Error {
+			devHelper?: string;
+		}
 	}
-	// interface Error {}
 	// interface PageData {}
 	// interface Platform {}
 }

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,15 +1,21 @@
 <script lang="ts">
 	import { page } from '$app/stores';
+	import RuleSpeechBubble from '$lib/components/common/RuleSpeechBubble.svelte';
+	import pirateMadsSrc from '$lib/assets/piratmads.png';
 </script>
 
-<div class="structure">
-	<h1>Det ser ut som noe har gått galt med siden!</h1>
+<div class="structure text-center">
+	<h1>Det ser ut som noe har gått galt!</h1>
 
-	<h2>
-		Oss stakkars utviklere av siden kan alltids gjøre feil, så for å hjelpe oss gjøre siden bedre kan du ta skjermbilde av meldingen under:
-	</h2>
+	<h2>Feil kan alltid skje, så for å hjelpe oss gjøre siden bedre kan du ta skjermbilde av meldingen under Mads</h2>
 
-	<h3>{$page.error?.devHelper}</h3>
+	<RuleSpeechBubble
+		mirror
+		imageSrc={pirateMadsSrc}
+		text="Husk å være snill med Magnus og William, selv om ikke alt alltid går på skinner. Det kan være vanskelig å lage gode nettsider!"
+	/>
 
-	<h3>{$page.error?.message}</h3>
+	<h4>{$page.error?.devHelper}</h4>
+
+	<p>{$page.error?.message}</p>
 </div>

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+	import { page } from '$app/stores';
+</script>
+
+<div class="structure">
+	<h1>Det ser ut som noe har gått galt med siden!</h1>
+
+	<h2>
+		Oss stakkars utviklere av siden kan alltids gjøre feil, så for å hjelpe oss gjøre siden bedre kan du ta skjermbilde av meldingen under:
+	</h2>
+
+	<h3>{$page.error?.devHelper}</h3>
+
+	<h3>{$page.error?.message}</h3>
+</div>

--- a/src/routes/+page.server.ts
+++ b/src/routes/+page.server.ts
@@ -3,6 +3,7 @@ import { error, fail } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => {
 	let { session, season } = await parent();
+
 	if (session) {
 		if (!season) return {};
 

--- a/src/routes/fantasy/+error.svelte
+++ b/src/routes/fantasy/+error.svelte
@@ -1,5 +1,0 @@
-<script lang="ts">
-	import { page } from '$app/stores';
-</script>
-
-<h1>{$page.error?.message}</h1>

--- a/src/routes/fantasy/+page.server.ts
+++ b/src/routes/fantasy/+page.server.ts
@@ -25,7 +25,6 @@ export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => 
 		)
 		.eq('players_seasons.season_id', season?.id);
 
-	// todo lol error
 	if (playersError) {
 		throw error(500, {
 			message: playersError.message,
@@ -43,7 +42,6 @@ export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => 
 		.eq('season_id', season?.id)
 		.maybeSingle();
 
-	// todo lol error
 	if (fantasyError) {
 		throw error(500, {
 			message: fantasyError.message,

--- a/src/routes/fantasy/+page.server.ts
+++ b/src/routes/fantasy/+page.server.ts
@@ -28,7 +28,8 @@ export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => 
 	// todo lol error
 	if (playersError) {
 		throw error(500, {
-			message: playersError.message
+			message: playersError.message,
+			devHelper: '/fantasy getting players with stats'
 		});
 	}
 
@@ -45,7 +46,8 @@ export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => 
 	// todo lol error
 	if (fantasyError) {
 		throw error(500, {
-			message: fantasyError.message
+			message: fantasyError.message,
+			devHelper: '/fantasy getting fantasy team for user'
 		});
 	}
 
@@ -71,9 +73,9 @@ export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => 
 		.eq('fantasy_teams_players.fantasy_team_id', fantasy.id);
 
 	if (fantasyTeamPlayersError) {
-		console.log('fantasyteamplerserror', fantasyTeamPlayersError);
 		throw error(500, {
-			message: fantasyTeamPlayersError.message
+			message: fantasyTeamPlayersError.message,
+			devHelper: '/fantasy getting fantasy team players'
 		});
 	}
 

--- a/src/routes/players/+page.server.ts
+++ b/src/routes/players/+page.server.ts
@@ -1,5 +1,6 @@
 import type { PageServerLoad } from './$types';
 import type { FullPlayer } from '$lib/types/newTypes';
+import { error } from '@sveltejs/kit';
 
 export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => {
 	let { season } = await parent();
@@ -27,7 +28,10 @@ export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => 
 
 	// todo lol error
 	if (playersError) {
-		return { players: [] };
+		throw error(500, {
+			message: playersError.message,
+			devHelper: 'players/ fetch all players with stats'
+		});
 	}
 
 	let mappedPlayers: FullPlayer[] = players.map((player) => {

--- a/src/routes/players/+page.server.ts
+++ b/src/routes/players/+page.server.ts
@@ -26,7 +26,6 @@ export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => 
 		)
 		.eq('season_id', season?.id);
 
-	// todo lol error
 	if (playersError) {
 		throw error(500, {
 			message: playersError.message,

--- a/src/routes/players/[slug]/+page.server.ts
+++ b/src/routes/players/[slug]/+page.server.ts
@@ -1,3 +1,4 @@
+import { error } from '@sveltejs/kit';
 import type { PageServerLoad } from './$types';
 
 export const load: PageServerLoad = async ({ locals: { supabase }, parent, params }) => {
@@ -26,9 +27,11 @@ export const load: PageServerLoad = async ({ locals: { supabase }, parent, param
 		.eq('player_id', params.slug)
 		.single();
 
-	// todo lol error
 	if (playerError) {
-		return {};
+		throw error(500, {
+			message: playerError.message,
+			devHelper: 'players/[slug] fetch player with stats'
+		});
 	}
 
 	return {

--- a/src/routes/teams/+page.server.ts
+++ b/src/routes/teams/+page.server.ts
@@ -10,7 +10,8 @@ export const load: PageServerLoad = async ({ locals: { supabase }, parent }) => 
 		const { data: teams, error: teamError } = await supabase.from('teams').select().eq('season_id', season.id);
 		if (teamError) {
 			throw error(500, {
-				message: teamError.message
+				message: teamError.message,
+				devHelper: '/teams fetching teams for a season'
 			});
 		}
 


### PR DESCRIPTION
Example: 
<img width="1254" alt="image" src="https://github.com/anderssonw/krakeroygutta/assets/61270418/d9ca1dd3-8c01-4f79-8cf0-3748b7dfc881">


After this was thrown from a ServerLoad:

```javascript
throw error(500, {
    message: 'lorem ipsum sucka my fuck and shutta fuck beep poop hella textlorem ipsu...',
    devHelper: '/fantasy, fetch players on team'
});
```

So for ServerLoads, we throw an error using `throw error(400-599, {})`, which will be catched by the root `+error.svelte` page. However, for actions, we will have to do a different catchall. Sending data regarding the failed server action like done here isn't "best practice" per se, but i think its fine. Will not work for actions as these _generally_ use `fail()` which is a redirect, not an error throw. All actions which do throw errors will send a generic message `Internal Error` for the message, according to docs

closes #60 